### PR TITLE
Fixing OOV tmesis case

### DIFF
--- a/docs/reference/jollyjumper.rst
+++ b/docs/reference/jollyjumper.rst
@@ -1,5 +1,5 @@
 jollyjumper
-====
+===========
 
 .. testsetup::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def read(*names, **kwargs):
 
 setup(
     name='jollyjumper',
-    version='0.3.0',
+    version='0.3.1',
     license='Apache Software License 2.0',
     description='Enjambment tool for Spanish texts',
     long_description='%s\n%s' % (

--- a/src/jollyjumper/__init__.py
+++ b/src/jollyjumper/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 from .core import get_enjambment  # noqa

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from unittest import mock
 
 import jollyjumper.core
@@ -99,3 +100,12 @@ def test_get_enjambment_no_monkeypatch():
     text = "maña-\nna"
     output = get_enjambment(text)
     assert output == {0: {'type': 'tmesis', 'on': ['maña', 'na']}}
+
+
+def test_get_enjambment_oov_no_monkeypatch():
+    text = "Yo miserable-\nmente. El coche-\ncito. No más-\nencabalgamiento."
+    output = get_enjambment(text)
+    assert output == {
+        0: {'type': 'tmesis', 'on': ['miserable', 'mente']},
+        1: {'type': 'tmesis', 'on': ['coche', 'cito']},
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ commands =
     python setup.py check --strict --metadata --restructuredtext
     check-manifest {toxinidir}
     flake8 src tests setup.py
-    isort --verbose --check-only --diff --recursive src tests setup.py
+    isort --check-only --diff --recursive src tests setup.py
 
 [testenv:spell]
 setenv =
@@ -66,6 +66,7 @@ deps =
 [testenv:docs]
 deps =
     -r{toxinidir}/docs/requirements.txt
+skip_install = true
 commands =
     sphinx-build {posargs:-E} -b doctest docs dist/docs
     sphinx-build {posargs:-E} -b html docs dist/docs


### PR DESCRIPTION
Fixes #25. Checking regular SpaCy lemma is in dicitonary when span text of tmesis is not
Bump version 0.3.0 → 0.3.1